### PR TITLE
Optimize permission fixer

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -72,7 +72,14 @@ run_permission_fixer(){
   # echo cd ~/projects/ctb-ruthjoy/jilliana/Tensorflow/workspace
   echo cd $(pwd)
   cd $(pwd)
+  
   myprogramout=nohup_perm_fixer_$USER.out
+  touch $myprogramout
+  # echo chmod g+rw nohup.out
+  # chmod g+rw nohup.out
+  echo chmod g+rw $myprogramout
+  chmod g+rw $myprogramout
+
   echo $myprogramout
   if [[ "$recurse" == \-* ]] && [[ "$recurse" == \-R ]] ; then
       echo nohup chmod -R g+rw * > $myprogramout 2>&1
@@ -81,10 +88,7 @@ run_permission_fixer(){
       echo nohup chmod g+rw * > $myprogramout 2>&1
       nohup chmod g+rw * > $myprogramout 2>&1
   fi
-  # echo chmod g+rw nohup.out
-  # chmod g+rw nohup.out
-  echo chmod g+rw $myprogramout
-  chmod g+rw $myprogramout
+  
   cd -
 }
 


### PR DESCRIPTION
The script `run_permission_fixer.sh` (and `utils.sh` has been optimized. I

t uses `lfs find` (Lustre file system) instead of `ls` and `find`, which were slow on the cluster's file system, 
Permission updates are limited to the subset of files owned by the `$USER` that don't have group write permissions. This is more efficient/targeted than everything everywhere all at once(tm). 

For my user, it completes in under 2m on all 305,659 files (counted in under 2 seconds) 

We don't need to run with Slurm SBATCH anymore.