### PR TITLE
Optimize Permission Fixer

### DIFF
--- a/object_detection_scripts/3_prediction_pipeline_postprocessing/post_process_detections/src/post_process.py
+++ b/object_detection_scripts/3_prediction_pipeline_postprocessing/post_process_detections/src/post_process.py
@@ -244,7 +244,12 @@ def main(detection_csv, mask=False, deduplicate_nests=False, merge_duplicate_nes
         df = remove_duplicate_nests(df, merge_duplicates=merge_duplicate_nests)
 
     print("Writing Output File ...")
-    df.to_csv(out_file, index=False)
+    
+    # Avoid detection_id=0 to prevent messy data / confusion with NA, "", missing value etc
+    id_offset = 11 # ids are two-digit (and above)
+    df = df.set_axis(pd.RangeIndex(start=id_offset, stop=len(df)+id_offset, step=1)) # reportedly faster than df.index += 1
+    
+    df.to_csv(out_file, index=True)
 
 
 if __name__ == '__main__':

--- a/utils.sh
+++ b/utils.sh
@@ -67,37 +67,148 @@ progress(){
 
 # progress "output/folder" "logs/folder"
 
-run_permission_fixer(){
-  recurse=$1
-  # echo cd ~/projects/ctb-ruthjoy/jilliana/Tensorflow/workspace
-  echo cd $(pwd)
-  cd $(pwd)
-  myprogramout=nohup_perm_fixer_$USER.out
-  echo $myprogramout
-  if [[ "$recurse" == \-* ]] && [[ "$recurse" == \-R ]] ; then
-      echo nohup chmod -R g+rw * > $myprogramout 2>&1
-      nohup chmod -R g+rw * > $myprogramout 2>&1
+# Reusable function to find files and directories
+find_files() {
+  local UNAME=${1:-$USER}
+  local target_group=${2:-$(stat -c "%G" .)} # group of pwd
+  local recurse=$3
+
+  if [[ "$recurse" == "-R" ]]; then 
+    # Recursively find files and directories
+    #                     with -print0 for null-terminated output
+    (lfs find . -user "$USER" -group "$target_group" -type d ; \
+     lfs find . -user "$USER" -group "$target_group" -type f)
   else
-      echo nohup chmod g+rw * > $myprogramout 2>&1
-      nohup chmod g+rw * > $myprogramout 2>&1
+    # Non-recursively find files and directories (maxdepth 1)
+    (lfs find . -maxdepth 1 -user "$USER" -group "$target_group" -type d ; \
+     lfs find . -maxdepth 1 -user "$USER" -group "$target_group" -type f)
   fi
-  # echo chmod g+rw nohup.out
-  # chmod g+rw nohup.out
-  echo chmod g+rw $myprogramout
-  chmod g+rw $myprogramout
-  cd -
 }
 
-run_permission_fixer_interrupt(){
-  # Update permissions of the nohup output file
-  echo cd $(pwd)
-  cd $(pwd)
-  myprogramout=nohup_perm_fixer_$USER.out
-  echo $myprogramout
+# Reusable function to process files and update permissions or count
+process_files() {
+  local files=$1
+  local change=$2
+  found=0
+  total=0
+
+  # Output either "Changing permissions" or "Only counting" based on change flag
+  [[ "$change" == "true" ]] && echo "Changing permissions." || echo "Not changing permission, only counting."
+
+  # Process each file
+  # while IFS= read -r -d '' file; do # null terminated strings
+  while read -r file; do # new line teminated strings
+    ((total++))
+    perm=$(stat -c "%a" "$file")  # Get octal permissions
+    group_perm=$(( (perm / 10) % 10 ))  # Extract the second digit (group permission)
+
+    # Check if the group has write permission
+    if [ $group_perm -lt 6 ]; then
+        # 2750: Group is sticky 'drwxr-s---'
+        # 660: Group has read and write permission. 'drwxrw----'
+        # 644: Group has only read permission. 'drwxr--r--'
+
+      echo "$perm, $group_perm: $file"
+      if [[ "$change" == "true" ]]; then
+        chmod g+rw "$file"
+        # Uncomment the line below to change the group as well
+        # chgrp "$target_group" "$file"
+      fi
+      ((found++))
+    fi
+  done <<< "$files"  # Here, we pass the files directly to the loop, 
+  # pipe (|) creates a subshell and the counters do not propagate back their values.
+
+  # Return the count of files processed
+  total_dir=$(lfs find . | wc -l)
+  echo "$found files counted/updated out of $total available: $total_dir all users."
+}
+
+run_permission_fixer() {
+  # Usage
+  # Args:
+  #   1: group name. The default is the group owner of the pwd (.), `stat -c "%G"``
+  #   2: '-R' for recusion. Any other value will only update the `log file` 'nohup_perm_fixer_$USER.out' 
+  # To apply this function recursively:
+  #     $ run_permission_fixer "your_target_group" "-R"
+  # To apply this function non-recursively:
+  #     $ run_permission_fixer "your_target_group"
+  # 
+
+  target_group=$1 # ${2:-$(stat -c "%G" .)} # group of pwd
+  recurse=${2:--1}
+  UNAME=$USER
+  
+  echo ""
+  date --iso-8601=seconds
+  echo "Operating in directory: $(pwd)"
+
+  # Recursively or non-recursively find and process files
+  echo "Changing group and permissions $([[ "$recurse" == "-R" ]] && echo "recursively" || echo "non-recursively")"
+
+  echo "Finding files owned by user=$UNAME and group=$target_group that does not have group 'w' permissions."
+
+  files=$(find_files $UNAME $target_group "$recurse")
+  process_files "$files" "true" # Update permissions for found files
+
+  echo "Permission fix completed."
+  echo ""
+  echo ""
+}
+
+run_permission_fixer_interrupt() {
+  target_group=$1
+
+  # Ensure we're operating on the current working directory
+  echo "Operating in directory: $(pwd)"
+  
+  # Output file for logging purposes
+  log_file=nohup_perm_fixer_$USER.out
+  touch "$log_file"
+  chmod g+w "$log_file"
+
+  date --iso-8601=seconds
+  echo "Operating in directory: $(pwd)"
+
+  # Log the permission change for nohup output
+  echo "Changing permissions of $log_file"
+  chmod g+rw "$log_file"
+
+  # Group and permissions update for the file
+  echo "Changing group and permissions of nohup_perm_fixer file"
+
+  # Process the file
+  files=$(lfs find "$log_file" -user "$USER" -group "$target_group" -type f)
+  process_files "$files" "true"
+
+  echo "Permission fix completed. Output logged to $log_file"
+}
 
 
-  echo chmod g+rw $myprogramout
-  chmod g+rw $myprogramout
-  cd -
+# Function to count files without changing permissions (with reuse of find_files and process_files)
+count_permission_files() {
+  local UNAME=${1:-$USER}
+  local target_group=${2:-$(stat -c "%G" .)} # group of pwd
+  local recurse=${3:--R}  # Default to recursive if no argument is provided
 
+  # Ensure we're operating on the current working directory
+  echo ""
+  date --iso-8601=seconds
+  echo "Operating in directory: $(pwd)"
+
+  # Find files based on the recursion flag
+  files=$(find_files $UNAME "$target_group" "$recurse")
+  process_files "$files" "false"  # Only count, without changing permissions
+
+  echo "Counting complete."
+  echo ""
+  echo ""
+}
+
+count_all(){
+  UNAME=${1:-$USER}
+  echo "Counting all files+folders with the command"
+  echo "  \$ time lfs find . -type f -type d | wc -l"
+  echo "Counting all files+folders owned by $UNAME with the comand"
+  echo "  \$ time lfs find . -type f -type d -user $UNAME | wc -l"
 }


### PR DESCRIPTION
The script run_permission_fixer.sh (and utils.sh has been optimized. I

t uses lfs find (Lustre file system) instead of ls and find, which were slow on the cluster's file system,
Permission updates are limited to the subset of files owned by the $USER that don't have group write permissions. This is more efficient/targeted than everything everywhere all at once(tm).

For my user, it completes in under 2m on all 305,659 files (counted in under 2 seconds)

We don't need to run with slurm SBATCH anymore.